### PR TITLE
Feature/web3 1.0.0.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, generics-sop, lib, zlib, web3-ethereum }:
+mkDerivation {
+  pname = "pixura-contracts";
+  version = "0.3.0.0";
+  src = ./.;
+  libraryHaskellDepends = [ base generics-sop web3-ethereum ];
+  libraryPkgconfigDepends = [ zlib ];
+  homepage = "https://github.com/Pixura/pixura-contracts#readme";
+  license = lib.licenses.bsd3;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "hs-web3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1661984067,
+        "narHash": "sha256-j+BzdnBFjS8qKjAqATzMi7/bxW8jX0/eh4Rv+yHstO8=",
+        "ref": "master",
+        "rev": "8f7459b834f7f42e5570e0004fe1fc6d4f7c6c9a",
+        "revCount": 631,
+        "type": "git",
+        "url": "ssh://git@github.com/superrare/hs-web3"
+      },
+      "original": {
+        "id": "hs-web3",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661353537,
+        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1661353537,
+        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "hs-web3": "hs-web3",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  # inspired by: https://serokell.io/blog/practical-nix-flakes#packaging-existing-applications
+  description = "A Hello World in Haskell with a dependency and a devShell";
+  inputs =
+    {
+      nixpkgs.url = "nixpkgs";
+      hs-web3 =
+        { url = "hs-web3";
+          inputs.nixpkgs.url = "nixpkgs";
+        };
+    };
+  outputs = { self, nixpkgs, hs-web3 }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        overlays = [ (self.overlay system) ];
+      });
+    in
+    {
+      overlay = (system: final: prev: {
+        pixura-contracts = final.haskell.packages.ghc924.callPackage (import ./default.nix) {
+          inherit (final) zlib;
+          inherit (hs-web3.packages.${system}) web3-ethereum;
+        };
+      });
+      packages = forAllSystems (system: {
+         pixura-contracts = nixpkgsFor.${system}.pixura-contracts;
+      });
+      defaultPackage = forAllSystems (system: self.packages.${system}.pixura-contracts);
+      checks = self.packages;
+      devShell = forAllSystems (system:
+        let haskellPackages = nixpkgsFor.${system}.haskell.packages.ghc924;
+        in haskellPackages.shellFor
+          {
+           packages = p: [self.packages.${system}.pixura-contracts];
+           withHoogle = true;
+           buildInputs = with haskellPackages;
+             [
+              haskell-language-server
+              cabal-install
+              ];
+           # Change the prompt to show that you are in a devShell
+           # shellHook = "export PS1='\\e[1;34mdev > \\e[0m'";
+           });
+    };
+}

--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,7 @@ default-extensions:
 dependencies:
   - base >=4.7 && <5
   - generics-sop
-  - web3
+  - web3-ethereum
 library:
   source-dirs: hs-contracts/src
   ghc-options: -Wall -Werror

--- a/pixura-contracts.cabal
+++ b/pixura-contracts.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 --
@@ -57,10 +57,45 @@ library
       Paths_pixura_contracts
   hs-source-dirs:
       hs-contracts/src
-  default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      EmptyCase
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeFamilyDependencies
+      TypeOperators
   ghc-options: -Wall -Werror
   build-depends:
       base >=4.7 && <5
     , generics-sop
-    , web3
+    , web3-ethereum
   default-language: Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, base, generics-sop, hpack, lib, web3 }:
+      mkDerivation {
+        pname = "pixura-contracts";
+        version = "0.3.0.0";
+        src = ./.;
+        libraryHaskellDepends = [ base generics-sop ];
+        libraryToolDepends = [ hpack ];
+        prePatch = "hpack";
+        homepage = "https://github.com/Pixura/pixura-contracts#readme";
+        license = lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
 allow-newer: true
 
 extra-deps:
-  - git: https://github.com/superrare/hs-web3
+  - git: git@github.com:superrare/hs-web3.git
     commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
     subdirs:
       - packages/bignum

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,24 @@
-resolver: lts-14.6
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/7/28.yaml
 
 packages:
   - "."
 
+allow-newer: true
+
 extra-deps:
-  - git: https://github.com/Pixura/hs-web3
-    commit: 175ca55de9be31054a8246d8c5ed8d7ce7813d83
+  - git: https://github.com/superrare/hs-web3
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    subdirs:
+      - packages/bignum
+      - packages/crypto
+      - packages/ethereum
+      - packages/hexstring
+      - packages/ipfs
+      - packages/jsonrpc
+      - packages/polkadot
+      - packages/provider
+      - packages/scale
+      - packages/solidity
+      - packages/web3
+  - relapse-1.0.0.0@sha256:b89ea23189e07f377be4e2a4deccf3d6ba7f547ed8ad77e27b35d78801efd81c

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -17,7 +17,8 @@ packages:
     commit: 175ca55de9be31054a8246d8c5ed8d7ce7813d83
 snapshots:
 - completed:
-    size: 524127
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/6.yaml
-    sha256: dc70dfb45e2c32f54719819bd055f46855dd4b3bd2e58b9f3f38729a2d553fbb
-  original: lts-14.6
+    sha256: 83cd17c52003e19611bd84c678f78fb0d98828ab8bc300a0b53ff2ae4f894ac5
+    size: 617444
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/7/28.yaml
+  original:
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/7/28.yaml

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,16 +5,155 @@
 
 packages:
 - completed:
-    name: web3
-    version: 0.8.3.2
-    git: https://github.com/Pixura/hs-web3
+    name: web3-bignum
+    subdir: packages/bignum
     pantry-tree:
-      size: 7979
-      sha256: df9f31cdfd98dd922c28f975b766c3eaf7d8bbcc8f3e0a4919deeaa69c6810e1
-    commit: 175ca55de9be31054a8246d8c5ed8d7ce7813d83
+      sha256: ca4107afd47e33fd1e8363c1ce69eb43f40de6bb5aaa0792a5e593783d1394d3
+      size: 449
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
   original:
-    git: https://github.com/Pixura/hs-web3
-    commit: 175ca55de9be31054a8246d8c5ed8d7ce7813d83
+    subdir: packages/bignum
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-crypto
+    subdir: packages/crypto
+    pantry-tree:
+      sha256: 57e5ce009c3f73ccf78e18f4258fe3921ae228b6fa177c9e626caddbb27206eb
+      size: 1507
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/crypto
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-ethereum
+    subdir: packages/ethereum
+    pantry-tree:
+      sha256: 04f590f29557679ac93f31c088de5117be5c730ce98f2b06a587e48ec808e040
+      size: 2858
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/ethereum
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: memory-hexstring
+    subdir: packages/hexstring
+    pantry-tree:
+      sha256: 1c28bfaa83b28f0c2d2b43e51c3452268812d84122683ed7d85f26a97fad64c7
+      size: 571
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/hexstring
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-ipfs
+    subdir: packages/ipfs
+    pantry-tree:
+      sha256: 3316b06d8c496048d90cbd1be588be13bd24ad3551372672a56dcc5e5bbfcab0
+      size: 1887
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/ipfs
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: jsonrpc-tinyclient
+    subdir: packages/jsonrpc
+    pantry-tree:
+      sha256: d30be0d5f2134212664cec16bb3aa70dd6964ed719ba5e3a6a90724bb587d9e6
+      size: 341
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/jsonrpc
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-polkadot
+    subdir: packages/polkadot
+    pantry-tree:
+      sha256: 5d6a35b6930ca96d555cd23bf736b7f8d058920bc60b81340c9c9bf81836cdc3
+      size: 4466
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/polkadot
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-provider
+    subdir: packages/provider
+    pantry-tree:
+      sha256: 58f280d49c51c3f3b8211756cf25f5a98c403c2fc0555ebaf3945936d23c5645
+      size: 331
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/provider
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: scale
+    subdir: packages/scale
+    pantry-tree:
+      sha256: 3138d83716ec15298d39780bd4a0081ca23f7a04947bfdb2cbd4152f2f87d69d
+      size: 1064
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/scale
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3-solidity
+    subdir: packages/solidity
+    pantry-tree:
+      sha256: 0e1c5e5008d36d5e2451be663479a91b4fda0819488ceaae46599772b69de650
+      size: 1768
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/solidity
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    name: web3
+    subdir: packages/web3
+    pantry-tree:
+      sha256: 519927f11aa1c041f5b23f66240da269fdce354559bd59ab432aa0da8f7e5912
+      size: 312
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+    version: 1.0.0.0
+  original:
+    subdir: packages/web3
+    commit: ac45f1fe34c2290739dcb7603a075c55385c2a51
+    git: git@github.com:superrare/hs-web3.git
+- completed:
+    pantry-tree:
+      sha256: a9ceb48aeb57519990a73a33032b97e7b4ce4d329e181ca36bc55425debf4748
+      size: 494
+    hackage: relapse-1.0.0.0@sha256:b89ea23189e07f377be4e2a4deccf3d6ba7f547ed8ad77e27b35d78801efd81c,1574
+  original:
+    hackage: relapse-1.0.0.0@sha256:b89ea23189e07f377be4e2a4deccf3d6ba7f547ed8ad77e27b35d78801efd81c
 snapshots:
 - completed:
     sha256: 83cd17c52003e19611bd84c678f78fb0d98828ab8bc300a0b53ff2ae4f894ac5


### PR DESCRIPTION
# Motivation

We have bumped our fork of the hs-web3 library. The template haskell code that generates the ABIs from the source code got a revamp and now cover more cases. We are updating all projects that use that code.

# Changes

- Use `web3-ethereum` v1.0.0.0 instead of hs-web3 0.8.3.2.
- Add nix flakes support (this is personal). 

# tests

It compiles and generates the code

![image](https://user-images.githubusercontent.com/1875145/187799969-dba523b8-bf12-4451-b540-f2c3fa4f416a.png)
